### PR TITLE
Add command-line example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ bytes = { version = "0.4", optional = true }
 tokio-codec = { version = "0.1", optional = true }
 
 [dev-dependencies]
-quickcheck = "0.7"
 bytes = "0.4"
+hex = "0.3"
+quickcheck = "0.7"
 tokio-codec = "0.1"
 

--- a/examples/uvi.rs
+++ b/examples/uvi.rs
@@ -1,0 +1,53 @@
+extern crate hex;
+extern crate unsigned_varint;
+
+use std::{env, process};
+use unsigned_varint::{decode, encode};
+
+pub fn main() {
+    let mut args = env::args().skip(1);
+
+    let mode =
+        if let Some(s) = args.next() {
+            s
+        } else {
+            println!("usage: -d <hex-encoded-string> | -e <number>");
+            process::exit(1)
+        };
+
+    match (mode.as_ref(), args.next()) {
+        ("-d", Some(xs)) => {
+            let v =
+                if let Ok(b) = hex::decode(&xs) {
+                    b
+                } else {
+                    println!("failed to decode hex string");
+                    process::exit(1)
+                };
+            match decode::u128(&v) {
+                Ok((n, _)) => println!("{}", n),
+                Err(e) => {
+                    println!("{}", e);
+                    process::exit(2)
+                }
+            }
+        }
+        ("-e", Some(xs)) => {
+            match xs.parse() {
+                Ok(n) => {
+                    let mut buf = encode::u128_buffer();
+                    let bytes = encode::u128(n, &mut buf);
+                    println!("{}", hex::encode(&bytes))
+                }
+                Err(e) => {
+                    println!("{}", e);
+                    process::exit(3)
+                }
+            }
+        }
+        _ => {
+            println!("usage: -d <hex-encoded-string> | -e <number>");
+            process::exit(1)
+        }
+    }
+}


### PR DESCRIPTION
A simple example which may sometimes be useful when converting back and forth between numbers and their unsigned-varint encoding. For example

```
> cargo run -q --example uvi -- -e 238402894
cefad671
> cargo run -q --example uvi -- -d cefad671
238402894
```