### PR TITLE
Use async/await for codec module.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,18 @@ edition = "2018"
 all-features = true
 
 [features]
-codec = ["bytes", "tokio-codec"]
+codec = ["futures-preview"]
 
 [dependencies]
-bytes = { version = "0.4", optional = true }
-tokio-codec = { version = "0.1", optional = true }
+futures-preview = { version = "0.3.0-alpha.17", optional = true }
 
 [dev-dependencies]
-bytes = "0.4"
 criterion = "0.2"
+futures-preview = "0.3.0-alpha.17"
 hex = "0.3"
 quickcheck = "0.8"
-tokio-codec = "0.1"
 
 [[bench]]
 name = "benchmark"
 harness = false
+

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Parity Technologies (UK) Ltd.
+// Copyright 2019 Parity Technologies (UK) Ltd.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
@@ -17,136 +17,123 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use bytes::{Buf, BufMut, Bytes, BytesMut, IntoBuf};
-use crate::{encode, decode::{self, Error}};
-use std::{io, marker::PhantomData, usize};
-use tokio_codec::{Encoder, Decoder};
+use crate::{encode, decode};
+use futures::prelude::*;
+use std::{fmt, io};
 
+macro_rules! encode_decode_impls {
+    ($mod: ident, $typ: ty, $enc: expr, $dec: expr, $arr: expr) => {
+        pub mod $mod {
+            use super::*;
 
-/// tokio-codec based encoder + decoder of unsigned-varint values
-#[derive(Default)]
-pub struct Uvi<T>(PhantomData<T>);
-
-// Implement tokio-codec `Encoder` + `Decoder` traits for unsigned integers.
-macro_rules! encoder_decoder_impls {
-    ($typ:ty, $enc:expr, $dec:expr, $arr:expr) => {
-        impl Encoder for Uvi<$typ> {
-            type Item = $typ;
-            type Error = io::Error;
-
-            fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+            /// Write an unsigned varint value to the given [`AsyncWrite`] impl.
+            pub async fn write<W>(item: $typ, dest: &mut W) -> Result<(), io::Error>
+            where
+                W: AsyncWrite + Unpin
+            {
                 let mut buf = $arr;
-                dst.extend_from_slice($enc(item, &mut buf));
+                let len = $enc(item, &mut buf);
+                dest.write_all(len).await?;
                 Ok(())
             }
-        }
 
-        impl Decoder for Uvi<$typ> {
-            type Item = $typ;
-            type Error = io::Error;
-
-            fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-                let (number, consumed) =
-                    match $dec(src.as_ref()) {
-                        Ok((n, rem)) => (n, src.len() - rem.len()),
-                        Err(Error::Insufficient) => return Ok(None),
-                        Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e))
-                    };
-                src.split_to(consumed);
-                Ok(Some(number))
+            /// Read an unsigned varint value from the given [`AsyncRead`] impl.
+            pub async fn read<R>(src: &mut R) -> Result<$typ, Error>
+            where
+                R: AsyncRead + Unpin
+            {
+                let mut b = $arr;
+                let mut i = 0;
+                loop {
+                    let n = src.read(&mut b[i .. i + 1]).await?;
+                    if n == 0 {
+                        return Err(Error::Io(io::ErrorKind::UnexpectedEof.into()))
+                    }
+                    if decode::is_last(b[i]) {
+                        break
+                    }
+                    i += 1
+                }
+                Ok($dec(&b[..= i])?.0)
             }
         }
     }
 }
 
-encoder_decoder_impls!(u8, encode::u8, decode::u8, encode::u8_buffer());
-encoder_decoder_impls!(u16, encode::u16, decode::u16, encode::u16_buffer());
-encoder_decoder_impls!(u32, encode::u32, decode::u32, encode::u32_buffer());
-encoder_decoder_impls!(u64, encode::u64, decode::u64, encode::u64_buffer());
-encoder_decoder_impls!(u128, encode::u128, decode::u128, encode::u128_buffer());
-encoder_decoder_impls!(usize, encode::usize, decode::usize, encode::usize_buffer());
+encode_decode_impls!(u8, u8, encode::u8, decode::u8, encode::u8_buffer());
+encode_decode_impls!(u16, u16, encode::u16, decode::u16, encode::u16_buffer());
+encode_decode_impls!(u32, u32, encode::u32, decode::u32, encode::u32_buffer());
+encode_decode_impls!(u64, u64, encode::u64, decode::u64, encode::u64_buffer());
+encode_decode_impls!(u128, u128, encode::u128, decode::u128, encode::u128_buffer());
+encode_decode_impls!(usize, usize, encode::usize, decode::usize, encode::usize_buffer());
 
-
-/// tokio-codec based encoder + decoder of unsigned-varint, length-prefixed bytes
-pub struct UviBytes<T = Bytes> {
-    /// the variable-length integer encoder/decoder
-    varint_codec: Uvi<usize>,
-    /// number of bytes expected in the current frame (for decoding only)
-    len: Option<usize>,
-    // maximum permitted number of bytes per frame
-    max: usize,
-    _ty: PhantomData<T>
+/// Error that may occur during decoding of unsigned varint values.
+#[derive(Debug)]
+pub enum Error {
+    /// The underlying I/O resource errored.
+    Io(io::Error),
+    /// Decoding the length failed.
+    Decode(decode::Error)
 }
 
-impl<T> Default for UviBytes<T> {
-    fn default() -> Self {
-        Self {
-            varint_codec: Default::default(),
-            len: None,
-            max: 128 * 1024 * 1024,
-            _ty: PhantomData
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Io(e) => write!(f, "i/o error: {}", e),
+            Error::Decode(e) => write!(f, "decode error: {}", e)
         }
     }
 }
 
-impl<T> UviBytes<T> {
-    /// Limit the maximum allowed length of bytes.
-    pub fn set_max_len(&mut self, val: usize) {
-        self.max = val
-    }
-
-    /// Return the maximum allowed number of bytes to encode/decode.
-    pub fn max_len(&self) -> usize {
-        self.max
-    }
-}
-
-impl<T: IntoBuf> Encoder for UviBytes<T> {
-    type Item = T;
-    type Error = io::Error;
-
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let bytes = item.into_buf();
-        if bytes.remaining() > self.max {
-            return Err(io::Error::new(io::ErrorKind::PermissionDenied, "len > max when encoding"));
-        }
-        self.varint_codec.encode(bytes.remaining(), dst)?;
-        dst.reserve(bytes.remaining());
-        dst.put(bytes);
-        Ok(())
-    }
-}
-
-impl<T> Decoder for UviBytes<T> {
-    type Item = BytesMut;
-    type Error = io::Error;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        loop {
-            match self.len.take() {
-                None => {
-                    self.len = self.varint_codec.decode(src)?;
-                    if self.len.is_none() {
-                        return Ok(None)
-                    }
-                    continue
-                }
-                Some(n) if n > self.max => {
-                    return Err(io::Error::new(io::ErrorKind::PermissionDenied, "len > max"))
-                }
-                Some(n) => {
-                    if src.len() < n {
-                        let add = n - src.len();
-                        src.reserve(add);
-                        self.len = Some(n);
-                        return Ok(None)
-                    } else {
-                        return Ok(Some(src.split_to(n)))
-                    }
-                }
-            }
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            Error::Decode(e) => Some(e)
         }
     }
 }
 
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+impl From<decode::Error> for Error {
+    fn from(e: decode::Error) -> Self {
+        Error::Decode(e)
+    }
+}
+
+// Tests //////////////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use futures::{executor::block_on, prelude::*};
+    use quickcheck::{QuickCheck, StdThreadGen};
+
+    #[test]
+    fn encode_decode_identity() {
+        fn prop(xs: Vec<u8>) -> bool {
+            let mut io = std::io::Cursor::new(vec![0; xs.len() + crate::encode::USIZE_BUF_LEN]);
+
+            // encode
+            block_on(super::usize::write(xs.len(), &mut io)).expect("encode len");
+            block_on(io.write_all(&xs)).expect("encode bytes");
+
+            io.set_position(0);
+
+            // decode
+            let n = block_on(super::usize::read(&mut io)).expect("decode len");
+            assert_eq!(n, xs.len());
+            let mut ys = vec![0; n];
+            block_on(io.read_exact(&mut ys)).expect("decode bytes");
+
+            xs == ys
+        }
+
+        QuickCheck::with_gen(StdThreadGen::new(512 * 1024)).quickcheck(prop as fn(Vec<u8>) -> bool)
+    }
+}
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -48,7 +48,7 @@ macro_rules! decode {
         for (i, b) in $buf.iter().cloned().enumerate() {
             let k = $typ::from(b & 0x7F);
             n |= k << (i * 7);
-            if b & 0x80 == 0 {
+            if is_last(b) {
                 return Ok((n, &$buf[i+1..]))
             }
             if i == $max_bytes {
@@ -57,6 +57,12 @@ macro_rules! decode {
         }
         Err(Error::Insufficient)
     }}
+}
+
+/// Is this the last byte of an unsigned varint?
+#[inline]
+pub fn is_last(b: u8) -> bool {
+    b & 0x80 == 0
 }
 
 /// Decode the given slice as `u8`.

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -40,7 +40,7 @@ macro_rules! encode {
 ///
 /// Returns the slice of encoded bytes.
 #[inline]
-pub fn u8(number: u8, buf: &mut [u8; U8_LEN]) -> &[u8] {
+pub fn u8(number: u8, buf: &mut [u8; U8_BUF_LEN]) -> &[u8] {
     encode!(number, buf)
 }
 
@@ -48,7 +48,7 @@ pub fn u8(number: u8, buf: &mut [u8; U8_LEN]) -> &[u8] {
 ///
 /// Returns the slice of encoded bytes.
 #[inline]
-pub fn u16(number: u16, buf: &mut [u8; U16_LEN]) -> &[u8] {
+pub fn u16(number: u16, buf: &mut [u8; U16_BUF_LEN]) -> &[u8] {
     encode!(number, buf)
 }
 
@@ -56,7 +56,7 @@ pub fn u16(number: u16, buf: &mut [u8; U16_LEN]) -> &[u8] {
 ///
 /// Returns the slice of encoded bytes.
 #[inline]
-pub fn u32(number: u32, buf: &mut [u8; U32_LEN]) -> &[u8] {
+pub fn u32(number: u32, buf: &mut [u8; U32_BUF_LEN]) -> &[u8] {
     encode!(number, buf)
 }
 
@@ -64,7 +64,7 @@ pub fn u32(number: u32, buf: &mut [u8; U32_LEN]) -> &[u8] {
 ///
 /// Returns the slice of encoded bytes.
 #[inline]
-pub fn u64(number: u64, buf: &mut [u8; U64_LEN]) -> &[u8] {
+pub fn u64(number: u64, buf: &mut [u8; U64_BUF_LEN]) -> &[u8] {
     encode!(number, buf)
 }
 
@@ -72,7 +72,7 @@ pub fn u64(number: u64, buf: &mut [u8; U64_LEN]) -> &[u8] {
 ///
 /// Returns the slice of encoded bytes.
 #[inline]
-pub fn u128(number: u128, buf: &mut [u8; U128_LEN]) -> &[u8] {
+pub fn u128(number: u128, buf: &mut [u8; U128_BUF_LEN]) -> &[u8] {
     encode!(number, buf)
 }
 
@@ -81,7 +81,7 @@ pub fn u128(number: u128, buf: &mut [u8; U128_LEN]) -> &[u8] {
 /// Returns the slice of encoded bytes.
 #[inline]
 #[cfg(target_pointer_width = "64")]
-pub fn usize(number: usize, buf: &mut [u8; USIZE_LEN]) -> &[u8] {
+pub fn usize(number: usize, buf: &mut [u8; USIZE_BUF_LEN]) -> &[u8] {
     u64(number as u64, buf)
 }
 
@@ -90,58 +90,66 @@ pub fn usize(number: usize, buf: &mut [u8; USIZE_LEN]) -> &[u8] {
 /// Returns the slice of encoded bytes.
 #[inline]
 #[cfg(target_pointer_width = "32")]
-pub fn usize(number: usize, buf: &mut [u8; USIZE_LEN]) -> &[u8] {
+pub fn usize(number: usize, buf: &mut [u8; USIZE_BUF_LEN]) -> &[u8] {
     u32(number as u32, buf)
 }
 
 /// Create new array buffer for encoding of `u8` values.
 #[inline]
-pub fn u8_buffer() -> [u8; U8_LEN] {
-    [0; U8_LEN]
+pub fn u8_buffer() -> [u8; U8_BUF_LEN] {
+    [0; U8_BUF_LEN]
 }
 
 /// Create new array buffer for encoding of `u16` values.
 #[inline]
-pub fn u16_buffer() -> [u8; U16_LEN] {
-    [0; U16_LEN]
+pub fn u16_buffer() -> [u8; U16_BUF_LEN] {
+    [0; U16_BUF_LEN]
 }
 
 /// Create new array buffer for encoding of `u32` values.
 #[inline]
-pub fn u32_buffer() -> [u8; U32_LEN] {
-    [0; U32_LEN]
+pub fn u32_buffer() -> [u8; U32_BUF_LEN] {
+    [0; U32_BUF_LEN]
 }
 
 /// Create new array buffer for encoding of `u64` values.
 #[inline]
-pub fn u64_buffer() -> [u8; U64_LEN] {
-    [0; U64_LEN]
+pub fn u64_buffer() -> [u8; U64_BUF_LEN] {
+    [0; U64_BUF_LEN]
 }
 
 /// Create new array buffer for encoding of `u128` values.
 #[inline]
-pub fn u128_buffer() -> [u8; U128_LEN] {
-    [0; U128_LEN]
+pub fn u128_buffer() -> [u8; U128_BUF_LEN] {
+    [0; U128_BUF_LEN]
 }
 
 /// Create new array buffer for encoding of `usize` values.
 #[inline]
-pub fn usize_buffer() -> [u8; USIZE_LEN] {
-    [0; USIZE_LEN]
+pub fn usize_buffer() -> [u8; USIZE_BUF_LEN] {
+    [0; USIZE_BUF_LEN]
 }
 
+/// Required buffer length to encode a `u8`.
+pub const U8_BUF_LEN: usize = 2;
 
-// Required lengths of encoding buffers:
+/// Required buffer length to encode a `u16`.
+pub const U16_BUF_LEN: usize = 3;
 
-const U8_LEN: usize = 2;
-const U16_LEN: usize = 3;
-const U32_LEN: usize = 5;
-const U64_LEN: usize = 10;
-const U128_LEN: usize = 19;
+/// Required buffer length to encode a `u32`.
+pub const U32_BUF_LEN: usize = 5;
 
+/// Required buffer length to encode a `u64`.
+pub const U64_BUF_LEN: usize = 10;
+
+/// Required buffer length to encode a `u128`.
+pub const U128_BUF_LEN: usize = 19;
+
+/// Required buffer length to encode a `usize`.
 #[cfg(target_pointer_width = "64")]
-const USIZE_LEN: usize = U64_LEN;
+pub const USIZE_BUF_LEN: usize = U64_BUF_LEN;
 
+/// Required buffer length to encode a `usize`.
 #[cfg(target_pointer_width = "32")]
-const USIZE_LEN: usize = U32_LEN;
+pub const USIZE_BUF_LEN: usize = U32_BUF_LEN;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,11 @@
 //! significant bit (MSB) in each byte indicates if another byte follows
 //! (MSB = 1), or not (MSB = 0).
 
+#![feature(async_await)]
+
 pub mod decode;
 pub mod encode;
+
 #[cfg(feature = "codec")]
 pub mod codec;
+

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -101,23 +101,3 @@ fn various() {
     )
 }
 
-#[cfg(feature = "codec")]
-#[test]
-fn identity_codec() {
-    use bytes::{Bytes, BytesMut};
-    use quickcheck::StdThreadGen;
-    use tokio_codec::{Encoder, Decoder};
-    use unsigned_varint::codec::UviBytes;
-
-    fn prop(mut xs: Vec<u8>) -> bool {
-        let mut codec = UviBytes::default();
-        xs.truncate(codec.max_len());
-        let input = Bytes::from(xs);
-        let mut buffer = BytesMut::with_capacity(input.len());
-        assert!(codec.encode(input.clone(), &mut buffer).is_ok());
-        input == codec.decode(&mut buffer).expect("Ok").expect("Some").freeze()
-    }
-
-    QuickCheck::with_gen(StdThreadGen::new(512 * 1024))
-        .quickcheck(prop as fn(Vec<u8>) -> bool)
-}


### PR DESCRIPTION
Use `futures::io::{AsyncRead, AsyncWrite}` instead of `bytes` and `tokio-codec`. Only supports the trivial writing and reading of the actual unsigned varint value to and from an `AsyncWrite` and `AsyncRead` implementation. Assumes reading individual bytes is efficient.