### PR TITLE
Add support for futures_codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ edition = "2018"
 all-features = true
 
 [features]
-codec = ["bytes", "tokio-codec"]
+codec = ["bytes", "tokio-codec", "futures_codec"]
 
 [dependencies]
 bytes = { version = "0.4", optional = true }
 tokio-codec = { version = "0.1", optional = true }
+futures_codec = { version = "0.2.5", optional = true }
 
 [dev-dependencies]
 bytes = "0.4"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -41,6 +41,15 @@ macro_rules! encoder_decoder_impls {
             }
         }
 
+        impl futures_codec::Encoder for Uvi<$typ> {
+            type Item = <Self as Encoder>::Item;
+            type Error = <Self as Encoder>::Error;
+
+            fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+                Encoder::encode(self, item, dst)
+            }
+        }
+
         impl Decoder for Uvi<$typ> {
             type Item = $typ;
             type Error = io::Error;
@@ -54,6 +63,15 @@ macro_rules! encoder_decoder_impls {
                     };
                 src.split_to(consumed);
                 Ok(Some(number))
+            }
+        }
+
+        impl futures_codec::Decoder for Uvi<$typ> {
+            type Item = <Self as Decoder>::Item;
+            type Error = <Self as Decoder>::Error;
+
+            fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+                Decoder::decode(self, src)
             }
         }
     }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -117,6 +117,15 @@ impl<T: IntoBuf> Encoder for UviBytes<T> {
     }
 }
 
+impl<T: IntoBuf> futures_codec::Encoder for UviBytes<T> {
+    type Item = <Self as Encoder>::Item;
+    type Error = <Self as Encoder>::Error;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        Encoder::encode(self, item, dst)
+    }
+}
+
 impl<T> Decoder for UviBytes<T> {
     type Item = BytesMut;
     type Error = io::Error;
@@ -149,4 +158,11 @@ impl<T> Decoder for UviBytes<T> {
     }
 }
 
+impl<T: IntoBuf> futures_codec::Decoder for UviBytes<T> {
+    type Item = <Self as Decoder>::Item;
+    type Error = <Self as Decoder>::Error;
 
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        Decoder::decode(self, src)
+    }
+}


### PR DESCRIPTION
For the switch to new futures, the `futures_codec` library can be used as a replacement for `tokio-codec`.