### PR TITLE
Support `futures_codec` and `tokio-codec`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unsigned-varint"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 description = "unsigned varint encoding"
@@ -13,17 +13,19 @@ all-features = true
 
 [features]
 codec = ["bytes", "tokio-codec"]
+futures-codec = ["bytes", "futures_codec"]
 
 [dependencies]
-bytes = { version = "0.4", optional = true }
-tokio-codec = { version = "0.1", optional = true }
+bytes = { version = "0.4.12", optional = true }
+tokio-codec = { version = "0.1.1", optional = true }
+futures_codec = { version = "0.2.5", optional = true }
 
 [dev-dependencies]
-bytes = "0.4"
-criterion = "0.2"
-hex = "0.3"
-quickcheck = "0.8"
-tokio-codec = "0.1"
+bytes = "0.4.12"
+criterion = "0.3.0"
+hex = "0.4.0"
+quickcheck = "0.9.0"
+tokio-codec = "0.1.1"
 
 [[bench]]
 name = "benchmark"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,5 @@
 
 pub mod decode;
 pub mod encode;
-#[cfg(feature = "codec")]
+#[cfg(any(feature = "codec", feature = "futures-codec"))]
 pub mod codec;


### PR DESCRIPTION
Like https://github.com/paritytech/unsigned-varint/pull/17 but using different feature flags for `tokio-codec` and `futures_codec`.