### PR TITLE
Update CHANGELOG and futures_codec version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.3 [2019-10-07]
+
+- In addition to `tokio-codec`, `futures_codec` is now supported (#18).
+- `decode::Error` now implements `Clone` (#19).
+- Code quality improvements (#20, #21).
+
 # 0.2.2 [2019-01-31]
 
 - Add package metadata for docs.rs to generate documentation for all features.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures-codec = ["bytes", "futures_codec"]
 [dependencies]
 bytes = { version = "0.4.12", optional = true }
 tokio-codec = { version = "0.1.1", optional = true }
-futures_codec = { version = "0.2.5", optional = true }
+futures_codec = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 bytes = "0.4.12"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Parity Technologies (UK) Ltd.
+// Copyright 2018-2019 Parity Technologies (UK) Ltd.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Parity Technologies (UK) Ltd.
+// Copyright 2018-2019 Parity Technologies (UK) Ltd.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Parity Technologies (UK) Ltd.
+// Copyright 2018-2019 Parity Technologies (UK) Ltd.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
The intention is to publish this as version 0.2.3 to crates.io next Monday (2019-10-7).