### PR TITLE
Update to `tokio-util` and `bytes` v0.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.0
+
+- Update to `bytes` v0.5.
+- Add support for `tokio-util` v0.2.
+- Remove support for `tokio-codec` v0.1.
+- Use `#[non_exhaustive]` in `decode::Error` and remove `__Nonexhaustive`.
+
 # 0.2.3 [2019-10-07]
 
 - In addition to `tokio-codec`, `futures_codec` is now supported (#18).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ codec = ["bytes", "tokio-util"]
 futures-codec = ["bytes", "futures_codec"]
 
 [dependencies]
-bytes = { package = "bytes", version = "0.5.3", optional = true }
+bytes = { version = "0.5.3", optional = true }
 futures_codec = { version = "0.3.4", optional = true }
 tokio-util = { version = "0.2", features = ["codec"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unsigned-varint"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 description = "unsigned varint encoding"
@@ -12,20 +12,19 @@ edition = "2018"
 all-features = true
 
 [features]
-codec = ["bytes", "tokio-codec"]
+codec = ["bytes", "tokio-util"]
 futures-codec = ["bytes", "futures_codec"]
 
 [dependencies]
-bytes = { version = "0.4.12", optional = true }
-tokio-codec = { version = "0.1.1", optional = true }
-futures_codec = { version = "0.3.0", optional = true }
+bytes = { package = "bytes", version = "0.5.3", optional = true }
+futures_codec = { version = "0.3.4", optional = true }
+tokio-util = { version = "0.2", features = ["codec"], optional = true }
 
 [dev-dependencies]
-bytes = "0.4.12"
-criterion = "0.3.0"
-hex = "0.4.0"
-quickcheck = "0.9.0"
-tokio-codec = "0.1.1"
+criterion = "0.3"
+hex = "0.4"
+quickcheck = "0.9"
+tokio-util = { version = "0.2", features = ["codec"] }
 
 [[bench]]
 name = "benchmark"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -40,7 +40,7 @@ fn bench_encode(c: &mut Criterion) {
 #[cfg(feature = "codec")]
 fn bench_codec(c: &mut Criterion) {
     use bytes::{Bytes, BytesMut};
-    use tokio_codec::{Decoder, Encoder};
+    use tokio_util::codec::{Decoder, Encoder};
     use unsigned_varint::codec::UviBytes;
 
     let data = Bytes::from(vec![1; 8192]);
@@ -49,7 +49,7 @@ fn bench_codec(c: &mut Criterion) {
 
     c.bench_function("codec", move |b| b.iter(|| {
         uvi_bytes.encode(data.clone(), &mut bytes).unwrap();
-        assert_eq!(data, uvi_bytes.decode(&mut bytes.take()).unwrap().unwrap())
+        assert_eq!(data, uvi_bytes.decode(&mut bytes.split_to(bytes.len())).unwrap().unwrap())
     }));
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -19,23 +19,21 @@
 
 use std::{self, fmt};
 
+/// Possible decoding errors.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Not enough input bytes.
     Insufficient,
     /// Input bytes exceed maximum.
-    Overflow,
-
-    #[doc(hidden)]
-    __Nonexhaustive
+    Overflow
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::Insufficient => f.write_str("not enough input bytes"),
-            Error::Overflow => f.write_str("input bytes exceed maximum"),
-            Error::__Nonexhaustive => f.write_str("__Nonexhaustive")
+            Error::Overflow => f.write_str("input bytes exceed maximum")
         }
     }
 }

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -106,7 +106,7 @@ fn various() {
 fn identity_codec() {
     use bytes::{Bytes, BytesMut};
     use quickcheck::StdThreadGen;
-    use tokio_codec::{Encoder, Decoder};
+    use tokio_util::codec::{Encoder, Decoder};
     use unsigned_varint::codec::UviBytes;
 
     fn prop(mut xs: Vec<u8>) -> bool {


### PR DESCRIPTION
This PR removes support for `tokio-codec` v0.1 and instead switches the `codec` feature to use `tokio-util` v0.2. It also updates the corresponding `bytes` dependency to v0.5.