### PR TITLE
Add support for decoding from `Read` and `AsyncRead` types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ futures-codec = ["bytes", "futures_codec"]
 
 [dependencies]
 bytes = { version = "0.5.3", optional = true }
+futures = { version = "0.3.4", optional = true }
 futures_codec = { version = "0.3.4", optional = true }
 tokio-util = { version = "0.2", features = ["codec"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio-util = { version = "0.2", features = ["codec"], optional = true }
 [dev-dependencies]
 criterion = "0.3"
 hex = "0.4"
+rand = "0.7"
 quickcheck = "0.9"
 tokio-util = { version = "0.2", features = ["codec"] }
 

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -28,7 +28,7 @@ macro_rules! gen {
         $(
             #[doc = " Try to read and decode a "]
             #[doc = $d]
-            #[doc = " from the given `AscynRead` type."]
+            #[doc = " from the given `AsyncRead` type."]
             pub async fn $name<R: AsyncRead + Unpin>(mut reader: R) -> Result<$t, ReadError> {
                 let mut b = encode::$b();
                 for i in 0 .. b.len() {

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -51,6 +51,7 @@ gen! {
     read_u16,   "`u16`",   u16,   u16_buffer;
     read_u32,   "`u32`",   u32,   u32_buffer;
     read_u64,   "`u64`",   u64,   u64_buffer;
+    read_u128,  "`u128`",  u128,  u128_buffer;
     read_usize, "`usize`", usize, usize_buffer
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -17,6 +17,8 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+//! `Encoder`/`Decoder` implementations for tokio or futures_codec.
+
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crate::{encode, decode::{self, Error}};
 use std::{io, marker::PhantomData, usize};

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -17,6 +17,8 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+//! Basic unsigned-varint decoding.
+
 use std::{self, fmt};
 
 /// Possible decoding errors.

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -46,7 +46,7 @@ macro_rules! decode {
         for (i, b) in $buf.iter().cloned().enumerate() {
             let k = $typ::from(b & 0x7F);
             n |= k << (i * 7);
-            if b & 0x80 == 0 {
+            if is_last(b) {
                 return Ok((n, &$buf[i+1..]))
             }
             if i == $max_bytes {
@@ -55,6 +55,12 @@ macro_rules! decode {
         }
         Err(Error::Insufficient)
     }}
+}
+
+/// Is this the last byte of an unsigned varint?
+#[inline]
+pub fn is_last(b: u8) -> bool {
+    b & 0x80 == 0
 }
 
 /// Decode the given slice as `u8`.

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -17,6 +17,8 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+//! Basic unsigned-varint encoding.
+
 macro_rules! encode {
     ($number:expr, $buf:expr) => {{
         let mut n = $number;

--- a/src/io.rs
+++ b/src/io.rs
@@ -48,6 +48,7 @@ gen! {
     read_u16,   "`u16`",   u16,   u16_buffer;
     read_u32,   "`u32`",   u32,   u32_buffer;
     read_u64,   "`u64`",   u64,   u64_buffer;
+    read_u128,  "`u128`",  u128,  u128_buffer;
     read_usize, "`usize`", usize, usize_buffer
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,91 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+// OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+//! Decode using [`std::io::Read`] types.
+
+use crate::{decode, encode};
+use std::{fmt, io};
+
+macro_rules! gen {
+    ($($name:ident, $d:expr, $t:ident, $b:ident);*) => {
+        $(
+            #[doc = " Try to read and decode a "]
+            #[doc = $d]
+            #[doc = " from the given `Read` type."]
+            pub fn $name<R: io::Read>(reader: R) -> Result<$t, ReadError> {
+                let mut buf = encode::$b();
+                for (i, b) in reader.bytes().take(buf.len()).enumerate() {
+                    let b = b?;
+                    buf[i] = b;
+                    if decode::is_last(b) {
+                        break
+                    }
+                }
+                Ok(decode::$t(&buf)?.0)
+            }
+        )*
+    }
+}
+
+gen! {
+    read_u8,    "`u8`",    u8,    u8_buffer;
+    read_u16,   "`u16`",   u16,   u16_buffer;
+    read_u32,   "`u32`",   u32,   u32_buffer;
+    read_u64,   "`u64`",   u64,   u64_buffer;
+    read_usize, "`usize`", usize, usize_buffer
+}
+
+/// Possible read errors.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ReadError {
+    Io(io::Error),
+    Decode(decode::Error)
+}
+
+impl fmt::Display for ReadError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ReadError::Io(e) => write!(f, "i/o error: {}", e),
+            ReadError::Decode(e) => write!(f, "decode error: {}", e)
+        }
+    }
+}
+
+impl std::error::Error for ReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        if let ReadError::Io(e) = self {
+            Some(e)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<io::Error> for ReadError {
+    fn from(e: io::Error) -> Self {
+        ReadError::Io(e)
+    }
+}
+
+impl From<decode::Error> for ReadError {
+    fn from(e: decode::Error) -> Self {
+        ReadError::Decode(e)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,7 @@
 
 pub mod decode;
 pub mod encode;
+pub mod io;
+
 #[cfg(any(feature = "codec", feature = "futures-codec"))]
 pub mod codec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,8 @@ pub mod decode;
 pub mod encode;
 pub mod io;
 
+#[cfg(feature = "futures")]
+pub mod aio;
+
 #[cfg(any(feature = "codec", feature = "futures-codec"))]
 pub mod codec;

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -121,3 +121,4 @@ fn identity_codec() {
     QuickCheck::with_gen(StdThreadGen::new(512 * 1024))
         .quickcheck(prop as fn(Vec<u8>) -> bool)
 }
+

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,0 +1,98 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+// OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use quickcheck::{Arbitrary, Gen};
+use unsigned_varint::{encode, io};
+
+#[test]
+fn read_arbitrary() {
+    fn property(n: RandomUvi) {
+        let mut r = std::io::Cursor::new(n.bytes());
+        match n {
+            RandomUvi::U8(n,  _) => assert_eq!(n, io::read_u8(&mut r).unwrap()),
+            RandomUvi::U16(n, _) => assert_eq!(n, io::read_u16(&mut r).unwrap()),
+            RandomUvi::U32(n, _) => assert_eq!(n, io::read_u32(&mut r).unwrap()),
+            RandomUvi::U64(n, _) => assert_eq!(n, io::read_u64(&mut r).unwrap())
+        }
+    }
+    quickcheck::quickcheck(property as fn(RandomUvi))
+}
+
+#[cfg(feature = "futures")]
+#[test]
+fn async_read_arbitrary() {
+    use unsigned_varint::aio;
+
+    fn property(n: RandomUvi) {
+        futures::executor::block_on(async move {
+            let mut r = futures::io::Cursor::new(n.bytes());
+            match n {
+                RandomUvi::U8(n,  _) => assert_eq!(n, aio::read_u8(&mut r).await.unwrap()),
+                RandomUvi::U16(n, _) => assert_eq!(n, aio::read_u16(&mut r).await.unwrap()),
+                RandomUvi::U32(n, _) => assert_eq!(n, aio::read_u32(&mut r).await.unwrap()),
+                RandomUvi::U64(n, _) => assert_eq!(n, aio::read_u64(&mut r).await.unwrap())
+            }
+        })
+    }
+    quickcheck::quickcheck(property as fn(RandomUvi))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RandomUvi {
+    U8(u8, Vec<u8>),
+    U16(u16, Vec<u8>),
+    U32(u32, Vec<u8>),
+    U64(u64, Vec<u8>)
+}
+
+impl RandomUvi {
+    fn bytes(&self) -> &[u8] {
+        match self {
+            RandomUvi::U8(_,  v) => v,
+            RandomUvi::U16(_, v) => v,
+            RandomUvi::U32(_, v) => v,
+            RandomUvi::U64(_, v) => v
+        }
+    }
+}
+
+impl Arbitrary for RandomUvi {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let n = g.next_u64();
+        match n % 4 {
+            0 => {
+                let mut b = encode::u8_buffer();
+                RandomUvi::U8(n as u8, Vec::from(encode::u8(n as u8, &mut b)))
+            }
+            1 => {
+                let mut b = encode::u16_buffer();
+                RandomUvi::U16(n as u16, Vec::from(encode::u16(n as u16, &mut b)))
+            }
+            2 => {
+                let mut b = encode::u32_buffer();
+                RandomUvi::U32(n as u32, Vec::from(encode::u32(n as u32, &mut b)))
+            }
+            _ => {
+                let mut b = encode::u64_buffer();
+                RandomUvi::U64(n, Vec::from(encode::u64(n, &mut b)))
+            }
+        }
+    }
+}
+

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -18,6 +18,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use quickcheck::{Arbitrary, Gen};
+use rand::Rng;
 use unsigned_varint::{encode, io};
 
 #[test]
@@ -29,6 +30,7 @@ fn read_arbitrary() {
             RandomUvi::U16(n, _)   => assert_eq!(n, io::read_u16(&mut r).unwrap()),
             RandomUvi::U32(n, _)   => assert_eq!(n, io::read_u32(&mut r).unwrap()),
             RandomUvi::U64(n, _)   => assert_eq!(n, io::read_u64(&mut r).unwrap()),
+            RandomUvi::U128(n, _)  => assert_eq!(n, io::read_u128(&mut r).unwrap()),
             RandomUvi::Usize(n, _) => assert_eq!(n, io::read_usize(&mut r).unwrap())
         }
     }
@@ -48,6 +50,7 @@ fn async_read_arbitrary() {
                 RandomUvi::U16(n, _)   => assert_eq!(n, aio::read_u16(&mut r).await.unwrap()),
                 RandomUvi::U32(n, _)   => assert_eq!(n, aio::read_u32(&mut r).await.unwrap()),
                 RandomUvi::U64(n, _)   => assert_eq!(n, aio::read_u64(&mut r).await.unwrap()),
+                RandomUvi::U128(n, _)  => assert_eq!(n, aio::read_u128(&mut r).await.unwrap()),
                 RandomUvi::Usize(n, _) => assert_eq!(n, aio::read_usize(&mut r).await.unwrap())
             }
         })
@@ -61,6 +64,7 @@ enum RandomUvi {
     U16(u16, Vec<u8>),
     U32(u32, Vec<u8>),
     U64(u64, Vec<u8>),
+    U128(u128, Vec<u8>),
     Usize(usize, Vec<u8>),
 }
 
@@ -71,6 +75,7 @@ impl RandomUvi {
             RandomUvi::U16(_, v) => v,
             RandomUvi::U32(_, v) => v,
             RandomUvi::U64(_, v) => v,
+            RandomUvi::U128(_, v) => v,
             RandomUvi::Usize(_, v) => v
         }
     }
@@ -78,8 +83,8 @@ impl RandomUvi {
 
 impl Arbitrary for RandomUvi {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
-        let n = g.next_u64();
-        match n % 5 {
+        let n: u128 = g.gen();
+        match n % 6 {
             0 => {
                 let mut b = encode::u8_buffer();
                 RandomUvi::U8(n as u8, Vec::from(encode::u8(n as u8, &mut b)))
@@ -94,7 +99,11 @@ impl Arbitrary for RandomUvi {
             }
             3 => {
                 let mut b = encode::u64_buffer();
-                RandomUvi::U64(n, Vec::from(encode::u64(n, &mut b)))
+                RandomUvi::U64(n as u64, Vec::from(encode::u64(n as u64, &mut b)))
+            }
+            4 => {
+                let mut b = encode::u128_buffer();
+                RandomUvi::U128(n, Vec::from(encode::u128(n, &mut b)))
             }
             _ => {
                 let mut b = encode::usize_buffer();

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -25,10 +25,11 @@ fn read_arbitrary() {
     fn property(n: RandomUvi) {
         let mut r = std::io::Cursor::new(n.bytes());
         match n {
-            RandomUvi::U8(n,  _) => assert_eq!(n, io::read_u8(&mut r).unwrap()),
-            RandomUvi::U16(n, _) => assert_eq!(n, io::read_u16(&mut r).unwrap()),
-            RandomUvi::U32(n, _) => assert_eq!(n, io::read_u32(&mut r).unwrap()),
-            RandomUvi::U64(n, _) => assert_eq!(n, io::read_u64(&mut r).unwrap())
+            RandomUvi::U8(n,  _)   => assert_eq!(n, io::read_u8(&mut r).unwrap()),
+            RandomUvi::U16(n, _)   => assert_eq!(n, io::read_u16(&mut r).unwrap()),
+            RandomUvi::U32(n, _)   => assert_eq!(n, io::read_u32(&mut r).unwrap()),
+            RandomUvi::U64(n, _)   => assert_eq!(n, io::read_u64(&mut r).unwrap()),
+            RandomUvi::Usize(n, _) => assert_eq!(n, io::read_usize(&mut r).unwrap())
         }
     }
     quickcheck::quickcheck(property as fn(RandomUvi))
@@ -43,10 +44,11 @@ fn async_read_arbitrary() {
         futures::executor::block_on(async move {
             let mut r = futures::io::Cursor::new(n.bytes());
             match n {
-                RandomUvi::U8(n,  _) => assert_eq!(n, aio::read_u8(&mut r).await.unwrap()),
-                RandomUvi::U16(n, _) => assert_eq!(n, aio::read_u16(&mut r).await.unwrap()),
-                RandomUvi::U32(n, _) => assert_eq!(n, aio::read_u32(&mut r).await.unwrap()),
-                RandomUvi::U64(n, _) => assert_eq!(n, aio::read_u64(&mut r).await.unwrap())
+                RandomUvi::U8(n,  _)   => assert_eq!(n, aio::read_u8(&mut r).await.unwrap()),
+                RandomUvi::U16(n, _)   => assert_eq!(n, aio::read_u16(&mut r).await.unwrap()),
+                RandomUvi::U32(n, _)   => assert_eq!(n, aio::read_u32(&mut r).await.unwrap()),
+                RandomUvi::U64(n, _)   => assert_eq!(n, aio::read_u64(&mut r).await.unwrap()),
+                RandomUvi::Usize(n, _) => assert_eq!(n, aio::read_usize(&mut r).await.unwrap())
             }
         })
     }
@@ -58,7 +60,8 @@ enum RandomUvi {
     U8(u8, Vec<u8>),
     U16(u16, Vec<u8>),
     U32(u32, Vec<u8>),
-    U64(u64, Vec<u8>)
+    U64(u64, Vec<u8>),
+    Usize(usize, Vec<u8>),
 }
 
 impl RandomUvi {
@@ -67,7 +70,8 @@ impl RandomUvi {
             RandomUvi::U8(_,  v) => v,
             RandomUvi::U16(_, v) => v,
             RandomUvi::U32(_, v) => v,
-            RandomUvi::U64(_, v) => v
+            RandomUvi::U64(_, v) => v,
+            RandomUvi::Usize(_, v) => v
         }
     }
 }
@@ -75,7 +79,7 @@ impl RandomUvi {
 impl Arbitrary for RandomUvi {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let n = g.next_u64();
-        match n % 4 {
+        match n % 5 {
             0 => {
                 let mut b = encode::u8_buffer();
                 RandomUvi::U8(n as u8, Vec::from(encode::u8(n as u8, &mut b)))
@@ -88,9 +92,13 @@ impl Arbitrary for RandomUvi {
                 let mut b = encode::u32_buffer();
                 RandomUvi::U32(n as u32, Vec::from(encode::u32(n as u32, &mut b)))
             }
-            _ => {
+            3 => {
                 let mut b = encode::u64_buffer();
                 RandomUvi::U64(n, Vec::from(encode::u64(n, &mut b)))
+            }
+            _ => {
+                let mut b = encode::usize_buffer();
+                RandomUvi::Usize(n as usize, Vec::from(encode::usize(n as usize, &mut b)))
             }
         }
     }


### PR DESCRIPTION
Adds support for reading unsigned-varint values from `std::io::Read` types and (optionally) from `futures::io::AsyncRead` types too.

Continuation of https://github.com/paritytech/unsigned-varint/pull/16.