### PR TITLE
nom: add a basic nom parser for unsigned-varint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ futures-io = { version = "0.3.4", optional = true }
 futures-util = { version = "0.3.4", features = ["io"], optional = true }
 futures_codec = { version = "0.3.4", optional = true }
 tokio-util = { version = "0.2", features = ["codec"], optional = true }
+nom = { version = "5", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -58,6 +58,27 @@ fn async_read_arbitrary() {
     quickcheck::quickcheck(property as fn(RandomUvi))
 }
 
+#[cfg(feature = "nom")]
+#[test]
+fn nom_read_arbitrary() {
+    use unsigned_varint::nom;
+
+    fn property(n: RandomUvi) {
+        let input = n.bytes();
+        let empty = &[][..];
+
+        match n {
+            RandomUvi::U8(n, _)    => assert_eq!((empty, n), nom::u8(input).unwrap()),
+            RandomUvi::U16(n, _)   => assert_eq!((empty, n), nom::u16(input).unwrap()),
+            RandomUvi::U32(n, _)   => assert_eq!((empty, n), nom::u32(input).unwrap()),
+            RandomUvi::U64(n, _)   => assert_eq!((empty, n), nom::u64(input).unwrap()),
+            RandomUvi::U128(n, _)  => assert_eq!((empty, n), nom::u128(input).unwrap()),
+            RandomUvi::Usize(n, _) => assert_eq!((empty, n), nom::usize(input).unwrap()),
+        }
+    }
+    quickcheck::quickcheck(property as fn(RandomUvi))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum RandomUvi {
     U8(u8, Vec<u8>),


### PR DESCRIPTION
If folks want to embed unsigned-varints within some binary schema using
Rust, they would most likely use nom[1] for parsing such a schema. This
is a trivial implementation of a nom parser to make it a little easier
to use unsigned-varint in such cases.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>
