### PR TITLE
Update dependencies to support tokio 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,19 +18,19 @@ futures = ["std", "futures-io", "futures-util"]
 futures-codec = ["std", "bytes", "futures_codec"]
 
 [dependencies]
-bytes = { version = "0.5.3", optional = true }
-futures-io = { version = "0.3.4", optional = true }
-futures-util = { version = "0.3.4", features = ["io"], optional = true }
-futures_codec = { version = "0.4", optional = true }
-tokio-util = { version = "0.3.1", features = ["codec"], optional = true }
-nom = { version = "5", optional = true }
+bytes = { version = "0.6.0", optional = true }
+futures-io = { version = "0.3.7", optional = true }
+futures-util = { version = "0.3.7", features = ["io"], optional = true }
+futures_codec = { version = "0.4.1", optional = true }
+tokio-util = { version = "0.4.0", features = ["codec"], optional = true }
+nom = { version = "5.1.2", optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
-futures-executor = "0.3.4"
-hex = "0.4"
-rand = "0.7"
-quickcheck = "0.9"
+criterion = "0.3.3"
+futures-executor = "0.3.7"
+hex = "0.4.2"
+rand = "0.7.3"
+quickcheck = "0.9.2"
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = ["std", "futures-io", "futures-util"]
 futures-codec = ["std", "bytes", "futures_codec"]
 
 [dependencies]
-bytes = { version = "0.6.0", optional = true }
+bytes = { version = "0.5.6", optional = true }
 futures-io = { version = "0.3.7", optional = true }
 futures-util = { version = "0.3.7", features = ["io"], optional = true }
 futures_codec = { version = "0.4.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytes = { version = "0.5.6", optional = true }
 futures-io = { version = "0.3.7", optional = true }
 futures-util = { version = "0.3.7", features = ["io"], optional = true }
 futures_codec = { version = "0.4.1", optional = true }
-tokio-util = { version = "0.4.0", features = ["codec"], optional = true }
+tokio-util = { version = "0.5.0", features = ["codec"], optional = true }
 nom = { version = "5.1.2", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures-io = { version = "0.3.7", optional = true }
 futures-util = { version = "0.3.7", features = ["io"], optional = true }
 futures_codec = { version = "0.4.1", optional = true }
 tokio-util = { version = "0.5.0", features = ["codec"], optional = true }
-nom = { version = "5.1.2", optional = true }
+nom = { version = "6.0.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.3"


### PR DESCRIPTION
## Overview

This PR updates dependencies to support the tokio 0.3 framework. Specifically the tokio-util crate. 