### PR TITLE
.github: Add and thus enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
In my eyes dependabot is a great help with keeping dependencies up-to-date. While a bit tedious, I think it proved valuable in rust-libp2p (see https://github.com/libp2p/rust-libp2p/pull/1744), thus I suggest to add it here as well. It would automate pull requests like https://github.com/paritytech/unsigned-varint/pull/38.