### PR TITLE
*: Switch futures_codec to asynchronous-codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.0 [unreleased]
+
+- Switch `futures_codec` to `asynchronous-codec`.
+
 # 0.5.1 [2020-09-08]
 
 - Improve docs (#36).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Switch `futures_codec` to `asynchronous-codec`.
 
+- Upgrade dependencies.
+
 # 0.5.1 [2020-09-08]
 
 - Improve docs (#36).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytes = { version = "1", optional = true }
 futures-io = { version = "0.3.4", optional = true }
 futures-util = { version = "0.3.4", features = ["io"], optional = true }
 asynchronous-codec = { version = "0.5", optional = true }
-tokio-util = { version = "0.3.1", features = ["codec"], optional = true }
+tokio-util = { version = "0.6", features = ["codec"], optional = true }
 nom = { version = "6", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unsigned-varint"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 description = "unsigned varint encoding"
@@ -15,13 +15,13 @@ all-features = true
 std = []
 codec = ["std", "bytes", "tokio-util"]
 futures = ["std", "futures-io", "futures-util"]
-futures-codec = ["std", "bytes", "futures_codec"]
+asynchronous_codec = ["std", "bytes", "asynchronous-codec"]
 
 [dependencies]
-bytes = { version = "0.5.3", optional = true }
+bytes = { version = "1", optional = true }
 futures-io = { version = "0.3.4", optional = true }
 futures-util = { version = "0.3.4", features = ["io"], optional = true }
-futures_codec = { version = "0.4", optional = true }
+asynchronous-codec = { version = "0.5", optional = true }
 tokio-util = { version = "0.3.1", features = ["codec"], optional = true }
 nom = { version = "6", optional = true }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -17,7 +17,7 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//! `Encoder`/`Decoder` implementations for tokio or futures_codec.
+//! `Encoder`/`Decoder` implementations for tokio or asynchronous_codec.
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crate::{encode, decode::{self, Error}};
@@ -67,8 +67,8 @@ macro_rules! encoder_decoder_impls {
             }
         }
 
-        #[cfg(feature = "futures-codec")]
-        impl futures_codec::Encoder for Uvi<$typ> {
+        #[cfg(feature = "asynchronous_codec")]
+        impl asynchronous_codec::Encoder for Uvi<$typ> {
             type Item = $typ;
             type Error = io::Error;
 
@@ -78,8 +78,8 @@ macro_rules! encoder_decoder_impls {
             }
         }
 
-        #[cfg(feature = "futures-codec")]
-        impl futures_codec::Decoder for Uvi<$typ> {
+        #[cfg(feature = "asynchronous_codec")]
+        impl asynchronous_codec::Decoder for Uvi<$typ> {
             type Item = $typ;
             type Error = io::Error;
 
@@ -181,8 +181,8 @@ impl<T> tokio_util::codec::Decoder for UviBytes<T> {
     }
 }
 
-#[cfg(feature = "futures-codec")]
-impl<T: Buf> futures_codec::Encoder for UviBytes<T> {
+#[cfg(feature = "asynchronous_codec")]
+impl<T: Buf> asynchronous_codec::Encoder for UviBytes<T> {
     type Item = T;
     type Error = io::Error;
 
@@ -191,8 +191,8 @@ impl<T: Buf> futures_codec::Encoder for UviBytes<T> {
     }
 }
 
-#[cfg(feature = "futures-codec")]
-impl<T> futures_codec::Decoder for UviBytes<T> {
+#[cfg(feature = "asynchronous_codec")]
+impl<T> asynchronous_codec::Decoder for UviBytes<T> {
     type Item = BytesMut;
     type Error = io::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub mod io;
 #[cfg(feature = "futures")]
 pub mod aio;
 
-#[cfg(any(feature = "codec", feature = "futures-codec"))]
+#[cfg(any(feature = "codec", feature = "asynchronous_codec"))]
 pub mod codec;
 
 #[cfg(feature = "nom")]


### PR DESCRIPTION
`futures-codec` has not been updated in the recent months. It still
depends on `bytes` `v0.5` preventing all downstream dependencies to
upgrade to `bytes` `v1.0`.

This commit replaces `futures_codec` in favor of [`asynchronous-codec`](https://github.com/mxinden/asynchronous-codec).
The latter is a fully upgraded fork of the former.

See also https://github.com/matthunz/futures-codec/pull/51 and https://github.com/matthunz/futures-codec/pull/57

In addition to the above, this pull request upgrades all dependencies.