### PR TITLE
CHANGELOG: Prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.6.0 [unreleased]
+# 0.6.0 [2021-01-11]
 
 - Switch `futures_codec` to `asynchronous-codec`.
 


### PR DESCRIPTION
Any objections to me cutting the `v0.6.0` release?

Once the release is published I will update https://github.com/libp2p/rust-libp2p/pull/1908 to finally update `bytes` and `tokio` in `rust-libp2p`.