### PR TITLE
*: Prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.0 [2021-02-04]
+
+- Update `asynchronous-codec` to `v0.6`.
+
 # 0.6.0 [2021-01-11]
 
 - Switch `futures_codec` to `asynchronous-codec`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unsigned-varint"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 description = "unsigned varint encoding"


### PR DESCRIPTION
I suggest to cut a release to unblock https://github.com/libp2p/rust-libp2p/pull/1944. Any objections?