### PR TITLE
Add conversions from our errors to std::io equivalents

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -23,7 +23,8 @@ use core::{self, fmt};
 
 /// Possible decoding errors.
 ///
-/// **Note**: The `std` feature is required for the `std::error::Error` impl.
+/// **Note**: The `std` feature is required for the `std::error::Error` impl and the conversion to
+/// `std::io::Error`.
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
@@ -45,6 +46,17 @@ impl fmt::Display for Error {
 /// Only available when the feature `std` is present.
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
+
+/// Only available when the feature `std` is present.
+#[cfg(feature = "std")]
+impl Into<std::io::Error> for Error {
+    fn into(self) -> std::io::Error {
+        match self {
+            Error::Insufficient => std::io::ErrorKind::UnexpectedEof,
+            Error::Overflow => std::io::ErrorKind::InvalidData,
+        }.into()
+    }
+}
 
 macro_rules! decode {
     ($buf:expr, $max_bytes:expr, $typ:ident) => {{

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -51,10 +51,11 @@ impl std::error::Error for Error {}
 #[cfg(feature = "std")]
 impl Into<std::io::Error> for Error {
     fn into(self) -> std::io::Error {
-        match self {
+        let kind = match self {
             Error::Insufficient => std::io::ErrorKind::UnexpectedEof,
             Error::Overflow => std::io::ErrorKind::InvalidData,
-        }.into()
+        };
+        std::io::Error::new(kind, self)
     }
 }
 
@@ -138,4 +139,3 @@ pub fn usize(buf: &[u8]) -> Result<(usize, &[u8]), Error> {
 pub fn usize(buf: &[u8]) -> Result<(usize, &[u8]), Error> {
     u32(buf).map(|(n, i)| (n as usize, i))
 }
-

--- a/src/io.rs
+++ b/src/io.rs
@@ -92,3 +92,12 @@ impl From<decode::Error> for ReadError {
         ReadError::Decode(e)
     }
 }
+
+impl Into<io::Error> for ReadError {
+    fn into(self) -> io::Error {
+        match self {
+            ReadError::Io(e) => e,
+            ReadError::Decode(e) => e.into(),
+        }
+    }
+}


### PR DESCRIPTION
Exactly what it says on the tin. This should make using this crate in `std::io`-based parsers a bit easier.