### PR TITLE
*: Bump patch version and extend changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.1 [unreleased]
+
+- Allow conversions from crate errors to std::io equivalents (#52).
+
 # 0.7.0 [2021-02-04]
 
 - Update `asynchronous-codec` to `v0.6`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unsigned-varint"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 description = "unsigned varint encoding"


### PR DESCRIPTION
Follow up to https://github.com/paritytech/unsigned-varint/pull/52. I am not allowed to push to `master` directly, thus this needs to go through the standard review process.