### PR TITLE
nom: switch to nom6-like errors

### DIFF
--- a/src/nom.rs
+++ b/src/nom.rs
@@ -20,7 +20,10 @@
 //! `nom` combinators to decode unsigned varints.
 
 use crate::decode::{self, Error};
-use nom::{error::ErrorKind, Err as NomErr, IResult, Needed};
+use nom::{
+    error::{Error as NomError, ErrorKind},
+    Err as NomErr, IResult, Needed,
+};
 
 macro_rules! gen {
     ($($type:ident, $d:expr);*) => {
@@ -28,10 +31,10 @@ macro_rules! gen {
             #[doc = " `nom` combinator to decode a variable-length encoded "]
             #[doc = $d]
             #[doc = "."]
-            pub fn $type(input: &[u8]) -> IResult<&[u8], $type, (&[u8], ErrorKind)> {
+            pub fn $type(input: &[u8]) -> IResult<&[u8], $type> {
                 let (n, remain) = decode::$type(input).map_err(|err| match err {
                     Error::Insufficient => NomErr::Incomplete(Needed::Unknown),
-                    Error::Overflow => NomErr::Error((input, ErrorKind::TooLarge)),
+                    Error::Overflow => NomErr::Error(NomError::new(input, ErrorKind::TooLarge)),
                 })?;
                 Ok((remain, n))
             }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -60,7 +60,7 @@ fn async_read_arbitrary() {
     quickcheck::quickcheck(property as fn(RandomUvi))
 }
 
-#[cfg(feature = "nom")]
+#[cfg(all(feature = "nom", feature = "std"))]
 #[test]
 fn nom_read_arbitrary() {
     use unsigned_varint::nom;


### PR DESCRIPTION
The preferred error types were changed in nom 6, and while the old ones
will compile, you'll find that nom doesn't like them very much any more.
It's much more preferable to use the new errors.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>