### PR TITLE
fix: require minimal encoding

### DIFF
--- a/src/nom.rs
+++ b/src/nom.rs
@@ -32,6 +32,7 @@ macro_rules! gen {
                 let (n, remain) = decode::$type(input).map_err(|err| match err {
                     Error::Insufficient => NomErr::Incomplete(Needed::Unknown),
                     Error::Overflow => NomErr::Error((input, ErrorKind::TooLarge)),
+                    Error::NotMinimal => NomErr::Error((input, ErrorKind::Verify)),
                 })?;
                 Ok((remain, n))
             }


### PR DESCRIPTION
ULEB128 technically allows any number trailing "MSB" zeros. However, this means that there are multiple ways to encode a single number. This is usually fine but can lead to security issues when the user assumes that a varint will round-trip and/or that there's exactly one encoding for some varint.

For example, code may check "is this a CID of type X" by matching the prefix against a known-byte string. This check only works when there's exactly one way to encode a varint.

As of https://github.com/multiformats/unsigned-varint/pull/19, the multiformats unsigned varint spec requires minimal encoding.