### PR TITLE
release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.7.1 [unreleased]
+# 0.7.1 [2021-02-08]
 
 - Allow conversions from crate errors to std::io equivalents (#52).
+- Reject non-minimally encoded varints (additional non-significant zero bytes).
 
 # 0.7.0 [2021-02-04]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.7.1 [2021-02-08]
 
 - Allow conversions from crate errors to std::io equivalents (#52).
-- Reject non-minimally encoded varints (additional non-significant zero bytes).
+- Reject non-minimally encoded varints (additional non-significant zero bytes) (#56).
 
 # 0.7.0 [2021-02-04]
 


### PR DESCRIPTION
- Update the changelog.
- Set the release date.

This is a patch release as it shouldn't break anything (unless users had malformed varints).