### PR TITLE
Add GHA to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily


### PR DESCRIPTION
This PR adds GitHub Actions monitoring to the Dependabot

Related issues:
https://github.com/paritytech/ci_cd/issues/407
https://github.com/paritytech/ci_cd/issues/464