### PR TITLE
fix: fix silent overflow in last byte

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -68,6 +68,11 @@ macro_rules! decode {
         let mut n = 0;
         for (i, b) in $buf.iter().cloned().enumerate() {
             let k = $typ::from(b & 0x7F);
+            let total_bits = $typ::BITS as usize;
+            // Check that the last byte does not overflow
+            if (i * 7 + 7) > total_bits  && usize::from(b) >= (1 << (total_bits - i * 7)) {
+                return Err(Error::Overflow);
+            }
             n |= k << (i * 7);
             if is_last(b) {
                 if b == 0 && i > 0 {


### PR DESCRIPTION
`decode::u8`, `decode::u16`, `decode::u32`, `decode::u64` etc, all silently overflow instead of returning Error::Overflow if there is extra data in the last byte decoded.

Also added some tests.