### PR TITLE
deps: upgrade `asynchronous-codec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.0 - unreleased
+
+- Update `asynchronous-codec` to `0.8` (#71)
+
 # 0.7.2 [2023-09-XX]
 
 - Update `tokio-util` to `0.7` (#59)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.8.0 - unreleased
 
-- Update `asynchronous-codec` to `0.8` (#71)
+- Update `asynchronous-codec` to `0.7` (#71)
 
 # 0.7.2 [2023-09-XX]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.8.0 - unreleased
+# 0.8.0 - [2023-11-01]
 
 - Update `asynchronous-codec` to `0.7` (#71)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ asynchronous_codec = ["std", "bytes", "asynchronous-codec"]
 bytes = { version = "1", optional = true }
 futures-io = { version = "0.3.4", optional = true }
 futures-util = { version = "0.3.4", features = ["io"], optional = true }
-asynchronous-codec = { version = "0.6", optional = true }
+asynchronous-codec = { version = "0.7", optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 nom = { version = "7", optional = true }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -69,10 +69,10 @@ macro_rules! encoder_decoder_impls {
 
         #[cfg(feature = "asynchronous_codec")]
         impl asynchronous_codec::Encoder for Uvi<$typ> {
-            type Item = $typ;
+            type Item<'a> = $typ;
             type Error = io::Error;
 
-            fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+            fn encode(&mut self, item: Self::Item<'_>, dst: &mut BytesMut) -> Result<(), Self::Error> {
                 self.serialise(item, dst);
                 Ok(())
             }
@@ -183,10 +183,10 @@ impl<T> tokio_util::codec::Decoder for UviBytes<T> {
 
 #[cfg(feature = "asynchronous_codec")]
 impl<T: Buf> asynchronous_codec::Encoder for UviBytes<T> {
-    type Item = T;
+    type Item<'a> = T;
     type Error = io::Error;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: Self::Item<'_>, dst: &mut BytesMut) -> Result<(), Self::Error> {
         self.serialise(item, dst)
     }
 }


### PR DESCRIPTION
The new release supports encoding of borrowed data. I don't think that is any use within this project though so I just did the simplest upgrade possible.

This is a breaking change because the traits are implemented on exported items. (FWIW: https://github.com/paritytech/unsigned-varint/pull/59 was also a breaking change but got incorrectly released as a patch release).